### PR TITLE
Add TZID parameter to DtStart and DtEnd for timezone handling

### DIFF
--- a/rapla-parser/src/ics.rs
+++ b/rapla-parser/src/ics.rs
@@ -1,6 +1,6 @@
 use ics::{
-    properties::{DtEnd, DtStart, Location, Organizer, RRule, Summary, TzName},
     parameters::TzIDParam,
+    properties::{DtEnd, DtStart, Location, Organizer, RRule, Summary, TzName},
     Daylight, Standard, TimeZone,
 };
 

--- a/rapla-parser/src/ics.rs
+++ b/rapla-parser/src/ics.rs
@@ -1,5 +1,6 @@
 use ics::{
     properties::{DtEnd, DtStart, Location, Organizer, RRule, Summary, TzName},
+    parameters::TzIDParam,
     Daylight, Standard, TimeZone,
 };
 

--- a/rapla-parser/src/ics.rs
+++ b/rapla-parser/src/ics.rs
@@ -49,8 +49,14 @@ impl Event {
 
         let mut ics_event = ics::Event::new(id, start.clone());
 
-        ics_event.push(DtStart::new(start));
-        ics_event.push(DtEnd::new(end));
+        let mut dtstart = DtStart::new(start);
+        dtstart.add(TzIDParam::new("Europe/Berlin"));
+
+        let mut dtend = DtEnd::new(end);
+        dtend.add(TzIDParam::new("Europe/Berlin"));
+
+        ics_event.push(dtstart);
+        ics_event.push(dtend);
         ics_event.push(Summary::new(&self.title));
 
         if let Some(location) = &self.location {


### PR DESCRIPTION
This pull request adds the TZID parameter to DtStart and DtEnd to ensure correct timezone handling for event start and end times.

This ensures that events are displayed in the correct timezone across different calendar applications.