### PR TITLE
feat: Add iCal description for all resources from rapla and use last child for location

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The resulting JSON response contains an array `"events"`, where each event is fo
 | `title`     | String                        | No       |
 | `location`  | String                        | Yes      |
 | `organizer` | String, comma-separated names | Yes      |
+| `description` | String, comma-separated resources | Yes      |
 
 ## Self-Hosting
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ To get started synchronizing your schedule to a calendar provider of your choice
 If you would like to receive the list of events as JSON rather than in the iCalendar format, you can add the `&json=true` query parameter to the Rapla URL.
 The resulting JSON response contains an array `"events"`, where each event is formatted as follows:
 
-| Field       | Format                        | Optional |
-| ----------- | ----------------------------- | -------- |
-| `date`      | `YYYY-MM-DD`                  | No       |
-| `start`     | `HH:MM`                       | No       |
-| `end`       | `HH:MM`                       | No       |
-| `title`     | String                        | No       |
-| `location`  | String                        | Yes      |
-| `organizer` | String, comma-separated names | Yes      |
+| Field         | Format                            | Optional |
+| ------------- | --------------------------------- | -------- |
+| `date`        | `YYYY-MM-DD`                      | No       |
+| `start`       | `HH:MM`                           | No       |
+| `end`         | `HH:MM`                           | No       |
+| `title`       | String                            | No       |
+| `location`    | String                            | Yes      |
+| `organizer`   | String, comma-separated names     | Yes      |
 | `description` | String, comma-separated resources | Yes      |
 
 ## Self-Hosting

--- a/rapla-parser/src/ics.rs
+++ b/rapla-parser/src/ics.rs
@@ -70,7 +70,7 @@ impl Event {
 
         if let Some(description) = &self.description {
             ics_event.push(Description::new(description));
-        } 
+        }
 
         ics_event
     }

--- a/rapla-parser/src/ics.rs
+++ b/rapla-parser/src/ics.rs
@@ -1,6 +1,6 @@
 use ics::{
     parameters::TzIDParam,
-    properties::{DtEnd, DtStart, Location, Organizer, RRule, Summary, TzName},
+    properties::{Description, DtEnd, DtStart, Location, Organizer, RRule, Summary, TzName},
     Daylight, Standard, TimeZone,
 };
 
@@ -67,6 +67,10 @@ impl Event {
         if let Some(organizer) = &self.organizer {
             ics_event.push(Organizer::new(organizer));
         }
+
+        if let Some(description) = &self.description {
+            ics_event.push(Description::new(description));
+        } 
 
         ics_event
     }

--- a/rapla-parser/src/parser.rs
+++ b/rapla-parser/src/parser.rs
@@ -109,10 +109,12 @@ fn parse_event_details(element: ElementRef, date: NaiveDate) -> Option<Event> {
 
     let title = details_split.next()?.replace("&amp;", "&");
 
-    let location = element
+    let resources = element
         .select(selector!("span.resource"))
-        .nth(1)
-        .map(|location| location.inner_html());
+        .map(|location| location.inner_html())
+        .collect::<Vec<_>>();
+
+    let location = resources.last().cloned();
 
     let persons = element
         .select(selector!("span.person"))
@@ -120,6 +122,7 @@ fn parse_event_details(element: ElementRef, date: NaiveDate) -> Option<Event> {
         .collect::<Vec<_>>();
 
     let organizer = persons.is_empty().not().then(|| persons.join(", "));
+    let description = resources.is_empty().not().then(|| resources.join(", "));
 
     Some(Event {
         date,
@@ -128,5 +131,6 @@ fn parse_event_details(element: ElementRef, date: NaiveDate) -> Option<Event> {
         title,
         location,
         organizer,
+        description,
     })
 }

--- a/rapla-parser/src/structs.rs
+++ b/rapla-parser/src/structs.rs
@@ -21,4 +21,5 @@ pub struct Event {
     pub location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organizer: Option<String>,
+    pub description: Option<String>,
 }

--- a/rapla-parser/src/structs.rs
+++ b/rapla-parser/src/structs.rs
@@ -21,5 +21,6 @@ pub struct Event {
     pub location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organizer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }


### PR DESCRIPTION
## Location Parsing

Previously, the location was parsed using `.nth(1)`, which only selects the second resource. However, there can be more than two resources in some cases, and based on my checks, the actual location is consistently the last resource. To address this, I’ve replaced `.nth(1)` with `.last()` to ensure the correct location is selected.

## Resource Handling in Description

To avoid losing any important information from the resources, I’ve added all resources to the iCal DESCRIPTION field (which corresponds to the “Notes” section in Apple Calendar). I initially considered removing the last resource (which is usually the location) from the description, but this would result in a resource being omitted if an actual location is missing. Therefore, I opted to include all resources in the description. The minor tradeoff is that the location will appear twice (once as the location field and again at the end of the description), which I think is neglectable. 

These changes make sure that the correct location is always used, and all relevant resource information is included in the calendar notes.